### PR TITLE
refactor: policy retrieval and parsing functionality

### DIFF
--- a/examples/examplePolicyLMB.lisp
+++ b/examples/examplePolicyLMB.lisp
@@ -1,83 +1,29 @@
 ;; Graphs
+;; This asset collection contains all information that is available to the public in the context of the LMB app.
+(define-graph public ("http://mu.semte.ch/graphs/public")
+  ("http://www.w3.org/2004/02/skos/core#ConceptScheme" -> "http://www.w3.org/2004/02/skos/core#prefLabel"
+    -> "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    -> "http://www.w3.org/2004/02/skos/core#inScheme")
+  ("http://www.w3.org/2004/02/skos/core#Concept" <- "http://www.w3.org/ns/regorg#orgStatus"
+    <- "http://lblod.data.gift/vocabularies/lmb/InstallatievergaderingStatus")
+  ("http://mu.semte.ch/vocabularies/ext/GeslachtCode" -> _)
+  ("http://data.vlaanderen.be/ns/besluit#Bestuurseenheid" <- _))
+
 ;; This asset collection contains all information that is available to all authenticated users in the context of the LMB app.
 (define-graph view-only-modules ("http://mu.semte.ch/graphs/authenticated/public")
   ("http://data.vlaanderen.be/ns/besluit#Bestuurseenheid" -> "http://mu.semte.ch/vocabularies/ext/viewOnlyModules"))
 
 ;; This asset collection contains all information that is available to users with the LoketLB-mandaatGebruiker role in the context of the LMB app.
 (define-graph organization-mandatendatabank ("http://mu.semte.ch/graphs/organizations/")
+  ("http://data.vlaanderen.be/ns/mandaat#Fractie" -> _)
   ("http://data.vlaanderen.be/ns/mandaat#Mandataris" -> _)
-  ("http://data.vlaanderen.be/ns/persoon#Persoon" x> "http://data.vlaanderen.be/ns/persoon#heeftGeboorte"
-    x> "http://data.vlaanderen.be/ns/persoon#registratie")
-  ("http://data.vlaanderen.be/ns/persoon#Persoon" <x "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan")
   ("http://data.vlaanderen.be/ns/persoon#Persoon" x> "http://data.vlaanderen.be/ns/persoon#registratie")
-  ("http://data.vlaanderen.be/ns/mandaat#Fractie" -> _))
-
-;; This asset collection contains all information that is available to the public in the context of the LMB app.
-(define-graph public ("http://mu.semte.ch/graphs/public")
-  ("http://www.w3.org/2004/02/skos/core#Concept" <- "http://lblod.data.gift/vocabularies/lmb/InstallatievergaderingStatus"
-    <- "http://www.w3.org/ns/regorg#orgStatus")
-  ("http://data.vlaanderen.be/ns/besluit#Bestuurseenheid" <- _)
-  ("http://www.w3.org/2004/02/skos/core#ConceptScheme" -> "http://www.w3.org/2004/02/skos/core#inScheme"
-    -> "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
-    -> "http://www.w3.org/2004/02/skos/core#prefLabel")
-  ("http://mu.semte.ch/vocabularies/ext/GeslachtCode" -> _))
+  ("http://data.vlaanderen.be/ns/persoon#Persoon" <x "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan")
+  ("http://data.vlaanderen.be/ns/persoon#Persoon" x> "http://data.vlaanderen.be/ns/persoon#heeftGeboorte"
+    x> "http://data.vlaanderen.be/ns/persoon#registratie"))
 
 
 ;; Groups
-;; This represents all logged in users of the system.
-(supply-allowed-group "authenticated-user"
-  :query "
-  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-  SELECT DISTINCT ?session_group ?session_role WHERE {
-    <SESSION_ID> ext:sessionGroup/mu:uuid ?session_group ;
-                 ext:sessionRole ?session_role .
-  }
-  ")
-
-;; This party collection represents all users who can access the information regarding police council mandates. This is defined by the members of communes that share the control of this police council.
-(supply-allowed-group "politieraad-lezer"
-  :parameters ("session_group" "session_role")
-  :query "
-  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-  SELECT DISTINCT ?session_group ?session_role WHERE {
-    <SESSION_ID> ext:sessionGroup ?original_session_group ;
-                  ext:sessionRole ?session_role .
-    ?original_session_group ext:deeltBestuurVan/mu:uuid ?session_group .
-
-    FILTER( ?session_role = \"LoketLB-mandaatGebruiker\" )
-  }
-  ")
-
-;; This party collection represents all users who can access the information regarding communes or OCMWs through their vendor api key
-(supply-allowed-group "vendor-users"
-  :parameters ("session_group" "session_role")
-  :query "
-  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-  PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
-  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-  SELECT DISTINCT ?session_group ?session_role WHERE {
-    VALUES ?session {
-      <SESSION_ID>
-    }
-    {{
-      ?session muAccount:canActOnBehalfOf/mu:uuid ?session_group ;
-                    muAccount:account/ext:sessionRole ?session_role .
-    } UNION {
-      ?session muAccount:account ?account .
-      ?session muAccount:canActOnBehalfOf/ext:isOCMWVoor/mu:uuid ?session_group ;
-                              muAccount:account/ext:sessionRole ?session_role .
-      ?session muAccount:canActOnBehalfOf/ext:isOCMWVoor/^<http://lblod.data.gift/vocabularies/lmb/heeftBestuurseenheid>/<http://lblod.data.gift/vocabularies/lmb/hasStatus> <http://data.lblod.info/id/concept/InstallatievergaderingStatus/a40b8f8a-8de2-4710-8d9b-3fc43a4b740e> .
-      VALUES ?account {
-        <http://data.lblod.info/vendors/14db001d-ea0f-4a8a-8453-c48547347588> # Cipal
-        <http://data.lblod.info/vendors/42edb420-08c7-4ede-9961-bc0e527d0f3b> # Green Valley
-        <http://data.lblod.info/vendors/dc62419e-1267-44e7-9562-0114e2708b6f> # Remmicom
-      }
-    }}
-  }
-  ")
-
 ;; This party collection represents all users who received the LoketLB-mandaatGebruiker role through ACM/IDM
 (supply-allowed-group "mandaten-users"
   :parameters ("session_group" "session_role")
@@ -105,8 +51,70 @@
   }
   ")
 
+;; This represents all logged in users of the system.
+(supply-allowed-group "authenticated-user"
+  :query "
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+  SELECT DISTINCT ?session_group ?session_role WHERE {
+    <SESSION_ID> ext:sessionGroup/mu:uuid ?session_group ;
+                 ext:sessionRole ?session_role .
+  }
+  ")
+
+;; This party collection represents all users who can access the information regarding police council mandates. This is defined by the members of communes that share the control of this police council.
+(supply-allowed-group "politieraad-lezer"
+  :parameters ("session_role" "session_group")
+  :query "
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+  SELECT DISTINCT ?session_group ?session_role WHERE {
+    <SESSION_ID> ext:sessionGroup ?original_session_group ;
+                  ext:sessionRole ?session_role .
+    ?original_session_group ext:deeltBestuurVan/mu:uuid ?session_group .
+
+    FILTER( ?session_role = \"LoketLB-mandaatGebruiker\" )
+  }
+  ")
+
+;; This party collection represents all users who can access the information regarding communes or OCMWs through their vendor api key
+(supply-allowed-group "vendor-users"
+  :parameters ("session_role" "session_group")
+  :query "
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+  SELECT DISTINCT ?session_group ?session_role WHERE {
+    VALUES ?session {
+      <SESSION_ID>
+    }
+    {{
+      ?session muAccount:canActOnBehalfOf/mu:uuid ?session_group ;
+                    muAccount:account/ext:sessionRole ?session_role .
+    } UNION {
+      ?session muAccount:account ?account .
+      ?session muAccount:canActOnBehalfOf/ext:isOCMWVoor/mu:uuid ?session_group ;
+                              muAccount:account/ext:sessionRole ?session_role .
+      ?session muAccount:canActOnBehalfOf/ext:isOCMWVoor/^<http://lblod.data.gift/vocabularies/lmb/heeftBestuurseenheid>/<http://lblod.data.gift/vocabularies/lmb/hasStatus> <http://data.lblod.info/id/concept/InstallatievergaderingStatus/a40b8f8a-8de2-4710-8d9b-3fc43a4b740e> .
+      VALUES ?account {
+        <http://data.lblod.info/vendors/14db001d-ea0f-4a8a-8453-c48547347588> # Cipal
+        <http://data.lblod.info/vendors/42edb420-08c7-4ede-9961-bc0e527d0f3b> # Green Valley
+        <http://data.lblod.info/vendors/dc62419e-1267-44e7-9562-0114e2708b6f> # Remmicom
+      }
+    }}
+  }
+  ")
+
 
 ;; Grants
+(grant (write read)
+  :to-graph organization-mandatendatabank
+  :for-allowed-group "mandaten-users")
+
+(grant (read)
+  :to-graph public
+  :for-allowed-group "public-user")
+
 (grant (read)
   :to-graph view-only-modules
   :for-allowed-group "authenticated-user")
@@ -118,12 +126,4 @@
 (grant (read)
   :to-graph organization-mandatendatabank
   :for-allowed-group "vendor-users")
-
-(grant (write read)
-  :to-graph organization-mandatendatabank
-  :for-allowed-group "mandaten-users")
-
-(grant (read)
-  :to-graph public
-  :for-allowed-group "public-user")
 

--- a/odrl-parser.lisp
+++ b/odrl-parser.lisp
@@ -44,12 +44,13 @@ filename."
                          (policy-retrieval:list-known-policies))))
     (loop
       for uri in policy-uris
-      do (with-open-file
-             (stream
-              (concatenate 'string output-directory (extract-filename uri) ".lisp")
-              :direction :output
-              :if-exists :supersede)
-           (write
-            ;; TODO(A): handle errors/nil from `make-rule-set'
-            (odrl:odrl-to-acl (policy-retrieval:parse-stored-policy uri))
-            :stream stream)))))
+      do (handler-case
+             (let ((conf (odrl:odrl-to-acl (policy-retrieval:parse-stored-policy uri))))
+               (with-open-file
+                 (stream
+                  (concatenate 'string output-directory (extract-filename uri) ".lisp")
+                  :direction :output
+                  :if-exists :supersede)
+               (write conf :stream stream)))
+           (error (e)
+             (format t "~& >> WARN: An error occurred when parsing policy \"~a\", no configuration written: \"~a\"" uri e))))))

--- a/odrl-parser.lisp
+++ b/odrl-parser.lisp
@@ -22,12 +22,12 @@ image."
 (hunchentoot:define-easy-handler (load-policy :uri "/load-policy") ()
   (setf (hunchentoot:content-type*) "text/plain")
   (load-policy-file)
-  (format nil "~& >> Loaded policy from 'config.nt'"))
+  (format t "~& >> Loaded policy from 'config.nt'"))
 
 (hunchentoot:define-easy-handler (generate-config :uri "/generate-config") (policy-name)
   (setf (hunchentoot:content-type*) "text/plain")
   (generate-authorisation-configuration policy-name)
-  (format nil "~& >> Generated authorisation configurations"))
+  (format t "~& >> Generated authorisation configurations"))
 
 (defun extract-filename (uri)
   "Extract a file name from the given uri."

--- a/odrl-parser.lisp
+++ b/odrl-parser.lisp
@@ -51,5 +51,5 @@ filename."
               :if-exists :supersede)
            (write
             ;; TODO(A): handle errors/nil from `make-rule-set'
-            (odrl:odrl-to-acl (policy-retrieval:make-rule-set uri))
+            (odrl:odrl-to-acl (policy-retrieval:parse-stored-policy uri))
             :stream stream)))))

--- a/odrl.lisp
+++ b/odrl.lisp
@@ -96,6 +96,7 @@
   configuration)
 
 (defmethod odrl-to-acl ((concept rule-set) &optional configuration)
+  (declare (ignore configuration))
   (call-next-method))
 
 ;; TODO(A): Properly handle calls where `configuration' is nil, in that case one could just return a

--- a/odrl.lisp
+++ b/odrl.lisp
@@ -146,7 +146,8 @@
     (with-slots (uri rules) object
       (format
        stream
-       "<~a> odrl:permission ~{~2t~a~^~&~}"
+       "~a <~a>~&~2t<permissions:~&~4t ~{~2t~a~^~&~}>"
+       (type-of object)
        uri
        (mapcar #'uri rules)))))
 
@@ -157,3 +158,29 @@
 (defmethod print-object ((concept action) stream)
   (print-unreadable-object (concept stream)
     (format stream "~a" (uri concept))))
+
+(defmethod print-object ((object asset-collection) stream)
+  (print-unreadable-object (object stream)
+    (with-slots (uri name description graph assets) object
+      (format
+       stream
+       "~a ~a~&~2t<name: ~a>~&~2t<description: ~a>~&~2t<graph: ~a>~&~2t<assets: ~{~&~4t~a~}>"
+       (type-of object)
+       uri
+       name
+       description
+       graph
+       assets))))
+
+(defmethod print-object ((object party-collection) stream)
+  (print-unreadable-object (object stream)
+    (with-slots (uri name description parameters query) object
+      (format
+       stream
+       "~a ~a~&~2t<name: ~a>~&~2t<description: ~a>~&~2t<parameters: ~a>~&~2t<query: ~a>"
+       (type-of object)
+       uri
+       name
+       description
+       parameters
+       query))))

--- a/packages.lisp
+++ b/packages.lisp
@@ -19,9 +19,8 @@
 
 (defpackage :policy-retrieval
   (:use :cl :mu-support :alexandria)
-  (:import-from :alexandria #:when-let*)
   (:export #:list-known-policies
-           #:make-rule-set)
+           #:parse-stored-policy)
   (:local-nicknames (:mu :mu-support))
   (:documentation "Functionality to retrieve ODRL policies from a backend and convert them from plain triples to the service's ODRL model."))
 

--- a/policy-retrieval.lisp
+++ b/policy-retrieval.lisp
@@ -5,16 +5,10 @@
 ;;
 ;; NOTE (13/09/2025): This is currently in a very rough state and requires at least to following
 ;; improvements:
+;; - Catch errors from instance creation. If the retrieved data is incorrect/incomplete, errors can
+;;   be thrown by the `make-instance' calls, currently these are never caught and will just
+;;   propagate to the top-level.
 ;; - Improve the overall quality and robustness of the code.
-;; - Reduce the number of queries performed, for example by retrieving most data in a single
-;;   construct query.  Because the rdf:list in the node shape can have an arbitrary length this will
-;;   probably need to be retrieved separately.
-;; - Prevent the creation of duplicate objects. Currently, the ODRL conversion starts from the
-;;   contained rules, as these resources are linked from a policy resource.  For each party and
-;;   asset collection linked to a rule a *new* object will be created, irrelevant of whether that
-;;   collection was already processed before.  This requires either changing how the data is
-;;   retrieved and parsed (related to the previous point) or keeping some state to check whether a
-;;   suitable object was already created (similar to what is done in the odrl-to-acl conversion.)
 ;; - Extract and generalise the parsing of the jsown objects received as input.  Currently this is
 ;;   rather ad-hoc and fragile.
 ;; - Convert the full URIs in replied to prefixed ones where possible.  This will make any
@@ -34,24 +28,46 @@
 (add-prefix "regorg" "http://www.w3.org/ns/regorg#")
 (add-prefix "persoon" "http://data.vlaanderen.be/ns/persoon#")
 
-(defparameter *policy-type* "odrl:Set"
-  "The resource type used for ODRL policies.")
+(defparameter predicates-plist
+  '(:dcterms-description "http://purl.org/dc/terms/description"
+    :ext-defined-by "http://mu.semte.ch/vocabularies/ext/definedBy"
+    :ext-graph-prefix "http://mu.semte.ch/vocabularies/ext/graphPrefix"
+    :ext-query-parameters "http://mu.semte.ch/vocabularies/ext/queryParameters"
+    :odrl-action "http://www.w3.org/ns/odrl/2/action"
+    :odrl-assignee "http://www.w3.org/ns/odrl/2/assignee"
+    :odrl-assigner "http://www.w3.org/ns/odrl/2/assigner"
+    :odrl-part-of "http://www.w3.org/ns/odrl/2/partOf"
+    :odrl-permission "http://www.w3.org/ns/odrl/2/permission"
+    :odrl-profile "http://www.w3.org/ns/odrl/2/profile"
+    :odrl-target "http://www.w3.org/ns/odrl/2/target"
+    :rdf-type "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    :sh-inverse-path "http://www.w3.org/ns/shacl#inversePath"
+    :sh-not "http://www.w3.org/ns/shacl#not"
+    :sh-path "http://www.w3.org/ns/shacl#path"
+    :sh-property "http://www.w3.org/ns/shacl#property"
+    :sh-target-class "http://www.w3.org/ns/shacl#targetClass"
+    :vcard-fn "http://www.w3.org/2006/vcard/ns#fn")
+  "A plist containing the full uris for the predicates that are used in ODRL policies.")
 
-(defun query-for-policies ()
-  "Retrieve a list of the URIs of all ODRL policies."
-  (sparql:select
-   (format nil "DISTINCT ~a" (mu:s-var "policy"))
-   (format nil "~a a ~a ." (s-var "policy") *policy-type*)))
+(defparameter resource-types-plist
+  '(:odrl-asset "http://www.w3.org/ns/odrl/2/Asset"
+    :odrl-asset-collection "http://www.w3.org/ns/odrl/2/AssetCollection"
+    :odrl-party "http://www.w3.org/ns/odrl/2/Party"
+    :odrl-party-collection "http://www.w3.org/ns/odrl/2/PartyCollection"
+    :odrl-permission "http://www.w3.org/ns/odrl/2/Permission"
+    :odrl-profile "http://www.w3.org/ns/odrl/2/Profile"
+    :odrl-set "http://www.w3.org/ns/odrl/2/Set"
+    :sh-node-shape "http://www.w3.org/ns/shacl#NodeShape"
+    :sh-property-shape "http://www.w3.org/ns/shacl#PropertyShape")
+  "A plist containing the full uris for the resources types used in ODRL policies.")
 
-(defun list-known-policies ()
-  "Construct a list of the resource URIs all ODRL policies found in the backend."
-  (mapcar (lambda (policy) (jsown:val (jsown:val policy "policy") "value")) (query-for-policies)))
+(defun predicate-uri (indicator)
+  "Return a string containing the full uri for the predicate matching INDICATOR."
+  (getf predicates-plist indicator))
 
-(defparameter subject-var (s-var "subject"))
-
-(defparameter predicate-var (s-var "predicate"))
-
-(defparameter object-var (s-var "object"))
+(defun type-uri (indicator)
+  "Return a string containing the full uri for the resource type matching INDICATOR."
+  (getf resource-types-plist indicator))
 
 ;; TODO(C): use proper regex for URIs
 (defun urip (str)
@@ -70,181 +86,344 @@
   "Escape the given URI."
   (sparql-escape (s-url uri)))
 
-;; TODO(C): Be more flexible/robust with the URI argument.
-;; TODO(B): Change to construct query
-(defun retrieve-triples (uri)
-  "Retrieve the triples for a resource with the given URI.
+(defun query-for-policies ()
+  "Retrieve a list of the URIs of all ODRL policies."
+  (sparql:select
+   (format nil "DISTINCT ~a" (mu:s-var "policy"))
+   (format nil "~a a ~a ." (s-var "policy") (escape-uri (type-uri :odrl-set)))))
 
-The provided URI can be a string containing a full resource uri or a uri prefixed with a known
-prefix."
-  (let ((uri (if (urip uri) (escape-uri uri) uri)))
-    (sparql:select
-     (format nil "DISTINCT ~a ~a ~a" subject-var predicate-var object-var)
-     (format nil "~a ~a ~a .~&FILTER (~a = ~a)" subject-var predicate-var object-var subject-var uri))))
+(defun list-known-policies ()
+  "Construct a list of the resource URIs all ODRL policies found in the backend."
+  (mapcar
+   (lambda (policy) (jsown:val (jsown:val policy "policy") "value"))
+   (query-for-policies)))
 
+;; TODO: Optimise/generalise query
+(defun query-policy-data (policy)
+  "Generate a construct query to retrieve all triples for POLICY."
+  (format
+   nil
+   "CONSTRUCT {
+      ?s ?p ?o .
+    } WHERE {
+      BIND (~a as ?policy)
+      {
+        SELECT DISTINCT ?s ?p ?o
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/odrl-policy> {
+            {
+              # Policy itself
+              ?s a odrl:Set ;
+                 ?p ?o .
+              FILTER (?s = ?policy)
+            } UNION {
+              # Permissions
+              ?policy odrl:permission ?s .
+              ?s a odrl:Permission ;
+                 ?p ?o .
+            } UNION {
+              # Party (Collection)
+              ?policy odrl:permission ?permission .
+              ?permission odrl:assignee|odrl:assigner ?s .
+              ?s ?p ?o .
+            } UNION {
+              # Asset collections
+              ?policy odrl:permission/odrl:target ?s .
+              ?s ?p ?o .
+            } UNION {
+              # Assets (Node shapes)
+              ?policy odrl:permission/odrl:target/^odrl:partOf ?s .
+              ?s a odrl:Asset ;
+                 ?p ?o .
+            } UNION {
+              # sh:not in node shape
+              ?policy odrl:permission/odrl:target/^odrl:partOf/sh:not ?s .
+              ?s ?p ?o .
+            } UNION {
+              # Property shapes in assets
+              ?policy odrl:permission/odrl:target/^odrl:partOf/sh:not?/sh:property ?s .
+              ?s ?p ?o .
+            } UNION {
+              # Property paths in property shapes
+              ?policy odrl:permission/odrl:target/^odrl:partOf/sh:not?/sh:property/sh:path ?s .
+              ?s ?p ?o .
+            } UNION {
+              # Inverse path in property paths
+              ?policy odrl:permission/odrl:target/^odrl:partOf/sh:not?/sh:property/sh:path/sh:inversePath ?s .
+              ?s ?p ?o .
+            }
+          }
+        }
+      }
+    }"
+   policy))
+
+(defun retrieve-policy (policy-uri)
+  "Retrieve all triples for a policy resource identified by POLICY-URI.
+
+POLICY must either be the full uri or a prefixed uri of the ODRL Set resource.
+The result is an RDF graph encoded as jsown objects for the triples.  Each triple has values for the
+variables \"s\", \"p\", and \"o\"."
+  (let ((uri (escape-uri (expand-uri policy-uri))))
+    (sparql:query (query-policy-data uri))))
+
+(defun parse-stored-policy (uri)
+  "Retrieve a policy resource URI from the backend and parse it into object instances."
+  (let ((triples (retrieve-policy uri)))
+    (make-rule-set uri triples)))
 
 ;;
 ;; Parse jsown objects
 ;;
-;; TODO(C): can probably be simplified using `jsown:filter'
-(defun object-from-triple (triple)
-  "Return the object for a TRIPLE."
-  (jsown:val triple (raw-content object-var)))
+(defun value-from-object (obj)
+  "Get the value given to the \"value\" keyword in OBJ."
+  (jsown:val-safe obj "value"))
 
-(defun object-value-from-triple (triple)
-  "Return the value of the object for TRIPLE."
-  (term-value-from-triple (raw-content object-var) triple))
+(defun triple-subject (triple)
+  "Return the jsown object that is the value for the subject of TRIPLE."
+  (jsown:val-safe triple "s"))
 
-(defun predicate-value-from-triple (triple)
-  "Return the value of predicate for TRIPLE."
-  (term-value-from-triple (raw-content predicate-var) triple))
+(defun triple-subject-value (triple)
+  "Return the jsown object that is the value for the subject of TRIPLE."
+  (value-from-object (triple-subject triple)))
 
-(defun term-value-from-triple (term triple)
-  "Return the value of TERM in TRIPLE."
-  (jsown:val (jsown:val triple term) "value"))
+(defun triple-predicate (triple)
+  "Return the jsown object that is the value for the predicate of TRIPLE."
+  (jsown:val-safe triple "p"))
 
-;; TODO(C): can probably be simplified using `jsown:filter'
-;; TODO(C): be more flexible/robust with the PREDICATE argument
-(defun triple-for-predicate-p (triple predicate)
-  "Check whether a TRIPLE has the given value as its PREDICATE.
+(defun triple-predicate-value (triple)
+  "Return the jsown object that is the value for the predicate of TRIPLE."
+  (value-from-object (triple-predicate triple)))
 
-The TRIPLE should be an object usable by the `jsown' library.
-The PREDICATE should be a string containing a prefixed predicate of its full uri, excluding the
-surrounding \"<\" and \">\"."
-  (string=
-   (jsown:val (jsown:val triple (raw-content predicate-var)) "value")
-   (expand-uri predicate)))
+(defun triple-object (triple)
+  "Return the jsown object that is the value for the object of TRIPLE."
+  (jsown:val-safe triple "o"))
 
-(defun filter-triples-for-predicate (predicate triples)
-  "Retrieve the triples for a given PREDICATE in a set of TRIPLES.
+(defun triple-object-value (triple)
+  "Return the jsown object that is the value for the object of TRIPLE."
+  (value-from-object (triple-object triple)))
 
-The PREDICATE should be a string containing a prefixed predicate of its full uri, excluding the
-surrounding \"<\" and \">\"."
-  (remove-if-not (lambda (triple) (triple-for-predicate-p triple predicate)) triples))
+(defun triples-for-predicate (predicate triples)
+  "Return all elements in TRIPLES that have PREDICATE as predicate value."
+  (remove-if-not
+   (lambda (triple) (string= predicate (triple-predicate-value triple)))
+   triples))
 
-(defun find-triple-for-predicate (predicate triples)
-  "Retrieve the (first) triple for a given PREDICATE in a set of TRIPLES.
+(defun triples-for-resource (resource triples)
+  "Return an triple objects in TRIPLES that have RESOURCE as subject."
+  (remove-if-not
+   (lambda (triple) (string= resource (triple-subject-value triple)))
+   triples))
 
-The PREDICATE should be a string containing a prefixed predicate of its full uri, excluding the
-surrounding \"<\" and \">\"."
-  (find-if (lambda (triple) (triple-for-predicate-p triple predicate)) triples))
+(defun triples-for-resource-predicate (resource predicate triples)
+  "Return all triple objects in TRIPLES that have RESOURCE as subject and PREDICATE as predicate."
+  (remove-if-not
+   (lambda (triple)
+     (and (string= resource (triple-subject-value triple))
+          (string= predicate (triple-predicate-value triple))))
+   triples))
 
-(defun object-value-for-predicate (predicate triples)
-  "Retrieve the value of the (first) object for PREDICATE in TRIPLES."
-  (object-value-from-triple (find-triple-for-predicate predicate triples)))
+(defun triples-for-predicate-object (predicate object triples)
+  "Return all triple objects in TRIPLES that have PREDICATE as predicate and OBJECT as object."
+  (remove-if-not
+   (lambda (triple)
+     (and (string= predicate (triple-predicate-value triple))
+          (string= object (triple-object-value triple))))
+   triples))
 
-(defun collect-object-for-predicate (predicate triples)
-  "Collect a list of all object values for PREDICATE in triples."
-  (mapcar #'object-value-from-triple (filter-triples-for-predicate predicate triples)))
+(defun list-parts-in-collection (uri triples)
+  "Return a list of the uris of all resources that are a part of the collection resource URI in TRIPLES."
+  (let ((parts (triples-for-predicate-object (predicate-uri :odrl-part-of) uri triples)))
+    (mapcar #'triple-subject-value parts)))
 
+(defun filter-resources-for-type (type triples)
+  "Filter the type triples for resources of TYPE in TRIPLES.
+
+TYPE should be a string containing a uri for a resource type."
+  (remove-if-not
+   (lambda (triple) (string= type (triple-object-value triple)))
+   (triples-for-predicate (predicate-uri :rdf-type) triples)))
+
+(defun list-resource-uris (type triples)
+  "Return a list containing the uri of each resource of TYPE in TRIPLES."
+  (mapcar #'triple-subject-value (filter-resources-for-type type triples)))
+
+(defun list-party-collections (triples)
+  "List the uris for ODRL party collection resources in TRIPLES."
+  (list-resource-uris (type-uri :odrl-party-collection) triples))
+
+(defun list-asset-collections (triples)
+  "List the uris for ODRL asset collection resources in TRIPLES."
+  (list-resource-uris (type-uri :odrl-asset-collection) triples))
+
+(defun list-assets (triples)
+  "List the uris for ODRL asset resources in TRIPLES."
+  (list-resource-uris (type-uri :odrl-asset) triples))
+
+(defun list-permissions-in-policy (triples)
+  "Return a list of the uris of all permissions in the policy defined by TRIPLES."
+  (mapcar
+   (lambda (triple) (triple-object-value triple))
+   (triples-for-predicate (predicate-uri :odrl-permission) triples)))
+
+;; NOTE (01/10/2025): These macros are use to make the init-forms in the `let' operators in the
+;; conversion functions more readable.
+(defmacro first-value-for-predicate (predicate triples)
+  "Return the value of the first object for PREDICATE encountered in TRIPLES."
+  `(triple-object-value (car (triples-for-predicate ,predicate ,triples))))
+
+(defmacro first-triple-for-resource (uri triples)
+  "Return the first triple with URI as subject in TRIPLES."
+  `(car (triples-for-resource ,uri ,triples)))
 
 ;;
 ;; Conversion to ODRL
 ;;
-(defun make-rule-set (uri)
-  "Make a `rule-set' instance for the data linked to the resource with URI."
-  (when-let* ((triples (retrieve-triples uri))
-              (permissions (filter-triples-for-predicate "odrl:permission" triples)))
-    (make-instance 'odrl:rule-set
-                   :uri uri
-                   :rules (mapcar #'make-permission permissions))))
+(defun find-concept-with-uri (uri concepts)
+  "Find the concept instance in CONCEPTS that has URI as value for its uri slot."
+  (when uri
+    (find-if
+     (lambda (concept) (string= (slot-value concept 'odrl::uri) uri))
+     concepts)))
 
-(defun make-permission (triple)
-  "Make a `permission' instance for the permission resource linked in TRIPLE."
-  (when-let* ((uri (object-value-from-triple triple))
-              (triples (retrieve-triples uri))
-              (action (find-triple-for-predicate "odrl:action" triples))
-              (target (find-triple-for-predicate "odrl:target" triples))
-              (assignee (find-triple-for-predicate "odrl:assignee" triples)))
-    (make-instance 'odrl:permission
-                   :uri uri
-                   :action (make-action action)
-                   :target (make-asset-collection target)
-                   :assignee (make-party-collection assignee))))
+(defun find-shape-with-uri (uri shapes)
+  "Find the shape instance in SHAPES that has URI as value for its uri slot."
+  (when uri
+    (find-if
+     (lambda (shape) (string= (slot-value shape 'shacl::uri) uri))
+     shapes)))
 
-(defun make-action (triple)
-  "Make an `action' instance with the given TRIPLE."
-  (make-instance 'odrl:action :uri (object-value-from-triple triple)))
+(defun make-rule-set (uri triples)
+  "Make an `odrl:rule-set' instance for the resource with URI."
+  (let ((asset-collections (make-asset-collections triples))
+        (party-collections (make-party-collections triples)))
+    (make-instance
+     'odrl:rule-set
+     :uri uri
+     :rules (mapcar
+             (lambda (permission)
+               (make-permission permission asset-collections party-collections triples))
+             (list-permissions-in-policy triples)))))
 
-(defun make-party-collection (triple)
-  "Make an `party-collection' instance for the assignee linked in TRIPLE."
-  (when-let* ((uri (object-value-from-triple triple))
-              (triples (retrieve-triples uri))
-              (name (object-value-for-predicate "vcard:fn" triples)))
-    (let ((description (object-value-for-predicate "dct:description" triples))
-          (parameters (collect-object-for-predicate "ext:queryParameters" triples))
-          (query (object-value-for-predicate "ext:definedBy" triples)))
-      (make-instance 'odrl:party-collection
-                     :uri uri
-                     :name name
-                     :description description
-                     :parameters parameters
-                     ;; TODO(B): this escaping should probably be applied to all strings
-                     :query (cl-ppcre:regex-replace-all "\"" query "\\\"")))))
-
-;; TODO: Should be able to handle prefixes collection URIs?
-(defun retrieve-assets-for-collection (collection)
-  "Retrieve a list of assets that are part of the COLLECTION."
+(defun make-party-collections (triples)
+  "Make an `odrl:party-collection' for each party collection resource in TRIPLES."
   (mapcar
-   (lambda (obj) (jsown:val (jsown:val obj "asset") "value"))
-   (sparql:select
-    (format nil "DISTINCT ?asset")
-    (format nil "?asset a odrl:Asset ; odrl:partOf ~a ." (escape-uri collection)))))
+   (lambda (uri) (make-party-collection uri triples))
+   (list-party-collections triples)))
 
-(defun make-asset-collection (triple)
-  "Make an `odrl:asset-collection' instance for the target linked in TRIPLE."
-  (when-let* ((uri (object-value-from-triple triple))
-              (triples (retrieve-triples uri))
-              (name (object-value-for-predicate "vcard:fn" triples))
-              (graph (object-value-for-predicate "ext:graphPrefix" triples))
-              (assets (retrieve-assets-for-collection uri)))
-    (let ((description (object-value-for-predicate "dct:description" triples)))
-      (make-instance 'odrl:asset-collection
-                     :uri uri
-                     :name name
-                     :description description
-                     :graph graph
-                     :assets (mapcar #'make-node-shape assets)))))
+(defun make-party-collection (uri policy-triples)
+  "Make an `odrl:party-collection' instance for the resource with URI."
+  (let* ((triples (triples-for-resource uri policy-triples))
+         (name (first-value-for-predicate (predicate-uri :vcard-fn) triples))
+         (description (first-value-for-predicate (predicate-uri :dcterms-description) triples))
+         (parameters (triples-for-predicate (predicate-uri :ext-query-parameters) triples))
+         (query (first-value-for-predicate (predicate-uri :ext-defined-by) triples)))
+    (make-instance
+     'odrl:party-collection
+     :uri uri
+     :name name
+     :description description
+     :parameters (mapcar #'triple-object-value parameters)
+     ;; TODO(B): this escaping should probably be applied to all strings
+     :query (when query (cl-ppcre:regex-replace-all "\"" query "\\\"")))))
 
-(defun make-node-shape (uri)
-  "Make a `shacl:node-shape' for the blank node with the given URI."
-  (when-let* ((triples (retrieve-triples uri))
-              (target-class (object-value-for-predicate "sh:targetClass" triples)))
-    (let* ((not-constraint (find-triple-for-predicate "sh:not" triples))
-           (properties (if not-constraint
-                           (let* ((not-uri (object-value-from-triple not-constraint))
-                                  (triples-in-not (retrieve-triples not-uri)))
-                             (filter-triples-for-predicate "sh:property" triples-in-not))
-                           (filter-triples-for-predicate "sh:property" triples))))
-      (make-instance 'shacl:node-shape
-                     :uri uri
-                     :target-class target-class
-                     :properties (mapcar #'make-property-shape properties)
-                     :notp (when not-constraint t)))))
+(defun make-asset-collections (triples)
+  "Make an `odrl:asset-collection' for each asset collection resource in TRIPLES."
+  (let ((assets (make-node-shapes triples)))
+    (mapcar
+     (lambda (uri) (make-asset-collection uri assets triples))
+     (list-asset-collections triples))))
+
+(defun make-asset-collection (uri assets policy-triples)
+  "Make an `odrl:asset-collection' instance for the resource with URI."
+  (let* ((triples (triples-for-resource uri policy-triples))
+         (name (first-value-for-predicate (predicate-uri :vcard-fn) triples))
+         (description (first-value-for-predicate (predicate-uri :dcterms-description) triples))
+         (graph (first-value-for-predicate (predicate-uri :ext-graph-prefix) triples))
+         (assets-in-collection (list-parts-in-collection uri policy-triples)))
+    (make-instance
+     'odrl:asset-collection
+     :uri uri
+     :name name
+     :description description
+     :graph graph
+     :assets (mapcar
+              (lambda (uri) (find-shape-with-uri uri assets))
+              assets-in-collection))))
+
+(defun make-node-shapes (triples)
+  "Make a `shacl:node-shape' instance for each ODRL asset resource in triples."
+  (mapcar
+   (lambda (uri) (make-node-shape uri triples))
+   (list-assets triples)))
+
+(defun make-node-shape (uri policy-triples)
+  "Make a `shacl:node-shape' for the resource with URI."
+  (let* ((triples (triples-for-resource uri policy-triples))
+         (target (first-value-for-predicate (predicate-uri :sh-target-class) triples))
+         ;; NOTE (01/10/2025): Node shapes may surround their property shapes with a "sh:not"
+         ;; constraint component.  The `not-triple' will have a non-nil value if that is the case,
+         ;; otherwise it will be nill.  This is used in `properties' to determine whether one has to
+         ;; go passed an additional blank node or not to find the properties in a node shape.
+         (not-triple (car (triples-for-predicate (predicate-uri :sh-not) triples)))
+         (properties (if not-triple
+                         (triples-for-resource-predicate
+                          (triple-object-value not-triple)
+                          (predicate-uri :sh-property)
+                          policy-triples)
+                         (triples-for-predicate (predicate-uri :sh-property) triples))))
+    (make-instance
+     'shacl:node-shape
+     :uri uri
+     :target-class target
+     :properties (mapcar
+                  (lambda (uri) (make-property-shape uri policy-triples))
+                  (mapcar #'triple-object-value properties))
+     :notp (when not-triple t))))
 
 (defun blank-node-uri-p (uri)
   "Check whether a given URI is for a blank."
   ;; TODO(C): match on alphanumeric characters in id part
   (cl-ppcre:scan "<?http://lblod.data.gift/bnode/.+>?" uri))
 
-(defun make-property-shape (triple)
-  "Make a `shacl::property-shape' from the provided TRIPLE."
-  (when-let* ((uri (object-value-from-triple triple))
-              (triples (retrieve-triples uri))
-              (path-triple (find-triple-for-predicate "sh:path" triples))
-              (path-uri (object-value-from-triple path-triple)))
+(defun make-property-shape (uri policy-triples)
+  "Make a `shacl:property-shape' instance for the resource with URI."
+  (let ((path (triple-object-value (first-triple-for-resource uri policy-triples))))
     (make-instance
      'shacl:property-shape
      :uri uri
-     :path (if (blank-node-uri-p path-uri)
-               (make-property-path path-uri)
-               path-uri))))
+     :path (if (blank-node-uri-p path)
+               (make-property-path path policy-triples)
+               path))))
 
-(defun make-property-path (uri)
-  "Make a `shacl:property-path' from the data linked to the resource with URI."
-  (when-let* ((triple (car (retrieve-triples uri)))
-              (predicate-path (predicate-value-from-triple triple))
-              (object (object-value-from-triple triple)))
-    (make-instance 'shacl:property-path
-                    :predicate-path predicate-path
-                    :object object)))
+(defun make-property-path (uri policy-triples)
+  "Make a `shacl:property-path' instance for the resource with URI."
+  (let ((triple (first-triple-for-resource uri policy-triples)))
+    (make-instance
+     'shacl:property-path
+     :predicate-path (triple-predicate-value triple)
+     :object (triple-object-value triple))))
+
+(defun make-permission (uri asset-col party-col policy-triples)
+  "Make an `odrl:permission' instance for the resource with URI.
+
+ASSET-COL and PARTY-COL should be lists of, respectively, `odrl:asset-collection' and
+`odrl:party-collection' instances with which the created `odrl:permission' instance can be linked."
+  (let* ((triples (triples-for-resource uri policy-triples))
+         (action (first-value-for-predicate (predicate-uri :odrl-action) triples))
+         (target (find-concept-with-uri
+                  (first-value-for-predicate (predicate-uri :odrl-target) triples)
+                  asset-col))
+         (assignee (find-concept-with-uri
+                    (first-value-for-predicate (predicate-uri :odrl-assignee) triples)
+                    party-col)))
+    (make-instance
+     'odrl:permission
+     :uri uri
+     :action (make-action action)
+     :target target
+     :assignee assignee)))
+
+(defun make-action (uri)
+  "Make an `odrl:action' instance for the given URI."
+  (make-instance 'odrl:action :uri uri))

--- a/shacl.lisp
+++ b/shacl.lisp
@@ -21,17 +21,20 @@
    ;; (components) in general.
    (notp :initarg :notp
          :type boolean
-         :initform nil))
+         :initform nil
+         :reader notp))
   (:documentation "A SHACL node shape"))
 
 (defclass property-shape (shape)
   ((path :initarg :path
-         :initform nil)) ; value is a predicate URI or a `property-path' instance
+         :initform nil
+         :reader path)) ; value is a predicate URI or a `property-path' instance
   (:documentation "A SHACL property shape"))
 
 (defclass property-path ()
   ((predicate-path :initarg :predicate-path
-                   :initform (error "A PREDICATE-PATH must be supplied for a property path"))
+                   :initform (error "A PREDICATE-PATH must be supplied for a property path")
+                   :reader predicate-path)
    (object :initarg :object
            :initform (error "An OBJECT must be supplied for a property path")
            :reader object))

--- a/shacl.lisp
+++ b/shacl.lisp
@@ -76,3 +76,28 @@ The special uri was introduced to allow user to specify \"all predicates\" in a 
      :predicate (if (typep path 'property-path)
                     (unless (is-empty-node-p (object path)) (object path))
                     (unless (is-empty-node-p path) path)))))
+
+
+;;
+;; Varia
+;;
+(defmethod print-object ((shape node-shape) stream)
+  (print-unreadable-object (shape stream)
+    (with-slots (uri properties notp) shape
+      (format
+       stream
+       "~a <~a>~&~2t<inverse: ~a>~&~2t<properties:~&~{~4t~a~&~}>"
+       (type-of shape)
+       uri
+       notp
+       properties))))
+
+(defmethod print-object ((shape property-shape) stream)
+  (print-unreadable-object (shape stream)
+    (with-slots (uri path) shape
+      (format stream "~a <~a>~&~4t<path: ~a>" (type-of shape) uri path))))
+
+(defmethod print-object ((path property-path) stream)
+  (print-unreadable-object (path stream)
+    (with-slots (predicate-path object) path
+      (format stream "~a <~a> <~a>" (type-of path) predicate-path object))))

--- a/shacl.lisp
+++ b/shacl.lisp
@@ -48,6 +48,7 @@
   (:documentation "Convert a SHACL shape to its corresponding sparql-parser entity."))
 
 (defmethod shacl-to-acl ((shape node-shape) &optional notp)
+  (declare (ignore notp))
   (with-slots (target-class properties notp) shape
     (make-instance 'acl:type-spec
                    :resource-type target-class

--- a/tests/policy-retrieval-data.lisp
+++ b/tests/policy-retrieval-data.lisp
@@ -1,0 +1,1275 @@
+(in-package :policy-retrieval)
+
+(defvar test-property-path
+  `((:OBJ
+     ("s" :OBJ ("type" . "uri")
+          ("value"
+           . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b12"))
+     ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#path"))
+     ("o" :OBJ ("type" . "uri")
+          ("value" . "http://data.vlaanderen.be/ns/persoon#registratie")))))
+
+(defvar test-party-collection-triples
+  '((:OBJ
+     ("s" :OBJ ("type" . "uri")
+      ("value" . "http://mu.semte.ch/vocabularies/ext/publicParty"))
+     ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/2006/vcard/ns#fn"))
+     ("o" :OBJ ("type" . "literal") ("value" . "Public user")))
+    (:OBJ
+     ("s" :OBJ ("type" . "uri")
+      ("value" . "http://mu.semte.ch/vocabularies/ext/publicParty"))
+     ("p" :OBJ ("type" . "uri")
+      ("value" . "http://mu.semte.ch/vocabularies/ext/definedBy"))
+     ("o" :OBJ ("type" . "literal")
+      ("value" . "SELECT DISTINCT ?s WHERE { ?s ?p ?o . }")))
+    (:OBJ
+     ("s" :OBJ ("type" . "uri")
+      ("value" . "http://mu.semte.ch/vocabularies/ext/publicParty"))
+     ("p" :OBJ ("type" . "uri")
+      ("value" . "http://purl.org/dc/terms/description"))
+     ("o" :OBJ ("type" . "literal")
+      ("value"
+       . "This party represent all (possibly not logged in) users of the system.")))
+    (:OBJ
+     ("s" :OBJ ("type" . "uri")
+      ("value" . "http://mu.semte.ch/vocabularies/ext/publicParty"))
+     ("p" :OBJ ("type" . "uri")
+      ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+     ("o" :OBJ ("type" . "uri")
+      ("value" . "http://www.w3.org/ns/odrl/2/PartyCollection")))))
+
+(defvar test-party-collection-triples-no-name
+  '((:OBJ
+     ("s" :OBJ ("type" . "uri")
+      ("value" . "http://mu.semte.ch/vocabularies/ext/publicParty"))
+     ("p" :OBJ ("type" . "uri")
+      ("value" . "http://mu.semte.ch/vocabularies/ext/definedBy"))
+     ("o" :OBJ ("type" . "literal")
+      ("value" . "SELECT DISTINCT ?s WHERE { ?s ?p ?o . }")))
+    (:OBJ
+     ("s" :OBJ ("type" . "uri")
+      ("value" . "http://mu.semte.ch/vocabularies/ext/publicParty"))
+     ("p" :OBJ ("type" . "uri")
+      ("value" . "http://purl.org/dc/terms/description"))
+     ("o" :OBJ ("type" . "literal")
+      ("value"
+       . "This party represent all (possibly not logged in) users of the system.")))
+    (:OBJ
+     ("s" :OBJ ("type" . "uri")
+      ("value" . "http://mu.semte.ch/vocabularies/ext/publicParty"))
+     ("p" :OBJ ("type" . "uri")
+      ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+     ("o" :OBJ ("type" . "uri")
+      ("value" . "http://www.w3.org/ns/odrl/2/PartyCollection")))))
+
+(defvar test-asset-collection-no-name
+  '((:OBJ
+     ("s" :OBJ ("type" . "uri")
+      ("value"
+       . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice"))
+     ("p" :OBJ ("type" . "uri")
+      ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+     ("o" :OBJ ("type" . "uri")
+      ("value" . "http://www.w3.org/ns/odrl/2/AssetCollection")))
+    (:OBJ
+     ("s" :OBJ ("type" . "uri")
+      ("value"
+       . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice"))
+     ("p" :OBJ ("type" . "uri")
+      ("value" . "http://mu.semte.ch/vocabularies/ext/graphPrefix"))
+     ("o" :OBJ ("type" . "uri")
+      ("value" . "http://mu.semte.ch/graphs/organizations/")))
+    (:OBJ
+     ("s" :OBJ ("type" . "uri")
+      ("value"
+       . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice"))
+     ("p" :OBJ ("type" . "uri")
+      ("value" . "http://purl.org/dc/terms/description"))
+     ("o" :OBJ ("type" . "literal")
+      ("value"
+       . "This asset collection contains all information that is available to users with the LoketLB-mandaatGebruiker role in the context of the LMB app.")))))
+
+(defvar test-asset-collection-no-graph
+  '((:OBJ
+     ("s" :OBJ ("type" . "uri")
+      ("value"
+       . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice"))
+     ("p" :OBJ ("type" . "uri")
+      ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+     ("o" :OBJ ("type" . "uri")
+      ("value" . "http://www.w3.org/ns/odrl/2/AssetCollection")))
+    (:OBJ
+     ("s" :OBJ ("type" . "uri")
+      ("value"
+       . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice"))
+     ("p" :OBJ ("type" . "uri")
+      ("value" . "http://purl.org/dc/terms/description"))
+     ("o" :OBJ ("type" . "literal")
+      ("value"
+       . "This asset collection contains all information that is available to users with the LoketLB-mandaatGebruiker role in the context of the LMB app.")))
+    (:OBJ
+     ("s" :OBJ ("type" . "uri")
+      ("value"
+       . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice"))
+     ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/2006/vcard/ns#fn"))
+     ("o" :OBJ ("type" . "literal") ("value" . "organization-mandatendatabank")))))
+
+(defvar test-asset-collection-no-name-or-graph
+  '((:OBJ
+     ("s" :OBJ ("type" . "uri")
+      ("value"
+       . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice"))
+     ("p" :OBJ ("type" . "uri")
+      ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+     ("o" :OBJ ("type" . "uri")
+      ("value" . "http://www.w3.org/ns/odrl/2/AssetCollection")))
+    (:OBJ
+     ("s" :OBJ ("type" . "uri")
+      ("value"
+       . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice"))
+     ("p" :OBJ ("type" . "uri")
+      ("value" . "http://purl.org/dc/terms/description"))
+     ("o" :OBJ ("type" . "literal")
+      ("value"
+       . "This asset collection contains all information that is available to users with the LoketLB-mandaatGebruiker role in the context of the LMB app.")))))
+
+(defvar test-permission-no-action
+  '((:OBJ
+     ("s" :OBJ ("type" . "uri")
+      ("value" . "http://mu.semte.ch/vocabularies/ext/allowReadForPublic"))
+     ("p" :OBJ ("type" . "uri")
+      ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+     ("o" :OBJ ("type" . "uri")
+      ("value" . "http://www.w3.org/ns/odrl/2/Permission")))
+    (:OBJ
+     ("s" :OBJ ("type" . "uri")
+      ("value" . "http://mu.semte.ch/vocabularies/ext/allowReadForPublic"))
+     ("p" :OBJ ("type" . "uri")
+      ("value" . "http://www.w3.org/ns/odrl/2/assignee"))
+     ("o" :OBJ ("type" . "uri")
+      ("value" . "http://mu.semte.ch/vocabularies/ext/publicParty")))
+    (:OBJ
+     ("s" :OBJ ("type" . "uri")
+      ("value" . "http://mu.semte.ch/vocabularies/ext/allowReadForPublic"))
+     ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/target"))
+     ("o" :OBJ ("type" . "uri")
+      ("value" . "http://mu.semte.ch/vocabularies/ext/lmbPublicSlice")))))
+
+(defvar test-policy-without-rules
+  '((:OBJ
+     ("s" :OBJ ("type" . "uri")
+      ("value" . "http://mu.semte.ch/vocabularies/ext/examplePolicyLMB"))
+     ("p" :OBJ ("type" . "uri")
+      ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+     ("o" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/Set")))))
+
+(defvar test-example-policy
+  '((:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/policeCouncilParty"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/2006/vcard/ns#fn"))
+  ("o" :OBJ ("type" . "literal") ("value" . "Politieraad lezer")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/mandaatGebruikerParty"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/queryParameters"))
+  ("o" :OBJ ("type" . "literal") ("value" . "session_group")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/mandaatGebruikerParty"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/definedBy"))
+  ("o" :OBJ ("type" . "literal")
+   ("value" . "
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+  SELECT DISTINCT ?session_group ?session_role WHERE {
+    <SESSION_ID> ext:sessionGroup/mu:uuid ?session_group ;
+                  ext:sessionRole ?session_role .
+    FILTER( ?session_role = \"LoketLB-mandaatGebruiker\" )
+  }
+  ")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/geslachtCodeAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#targetClass"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/GeslachtCode")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b10"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#path"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/viewOnlyModules")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/allowReadForMandatarisOrg"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/assignee"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/mandaatGebruikerParty")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/conceptSchemeAsset"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/partOf"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/lmbPublicSlice")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/conceptSchemeAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#targetClass"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/2004/02/skos/core#ConceptScheme")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowReadForVendorOnMandatarisOrg"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/assigner"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/lmbSystem")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/personMultipleExcludedAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#NodeShape")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/vendorGebruikerParty"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/PartyCollection")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/lmbPublicSlice"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/AssetCollection")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowWriteForMandatarisOrg"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/assignee"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/mandaatGebruikerParty")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/fractieAsset"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/partOf"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/allowReadForPublic"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/target"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/lmbPublicSlice")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/mandatarisAsset"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/partOf"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/administrativeUnitAsset"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#property"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b4")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/personMultipleExcludedAsset"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#not"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b13")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/policeCouncilParty"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://purl.org/dc/terms/description"))
+  ("o" :OBJ ("type" . "literal")
+   ("value"
+    . "This party collection represents all users who can access the information regarding police council mandates. This is defined by the members of communes that share the control of this police council.")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/geslachtCodeAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#NodeShape")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/policeCouncilParty"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/PartyCollection")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowReadForPoliceCouncilOnMandatarisOrg"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/assigner"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/lmbSystem")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/conceptAsset"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#property"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b6")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/conceptSchemeAsset"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#property"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b2")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/allowReadForMandatarisOrg"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/assigner"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/lmbSystem")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/2006/vcard/ns#fn"))
+  ("o" :OBJ ("type" . "literal") ("value" . "organization-mandatendatabank")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowWriteForMandatarisOrg"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/assigner"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/lmbSystem")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b13"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#property"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b15")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/conceptSchemeAsset"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#property"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b3")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/conceptAsset"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#property"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b8")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/personAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/Asset")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowReadForPoliceCouncilOnMandatarisOrg"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/assignee"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/policeCouncilParty")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowReadForAuthenticatedOnViewOnlyModules"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/assignee"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/authenticatedParty")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/administrativeUnitViewOnlyAsset"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#property"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b10")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b16"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#property"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b17")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowReadForVendorOnMandatarisOrg"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/assignee"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/vendorGebruikerParty")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/allowReadForPublic"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/assigner"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/lmbSystem")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/administrativeUnitAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#NodeShape")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/lmbSystem"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/2006/vcard/ns#fn"))
+  ("o" :OBJ ("type" . "literal") ("value" . "LMB System")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/publicParty"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/2006/vcard/ns#fn"))
+  ("o" :OBJ ("type" . "literal") ("value" . "Public user")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/lmbSystem"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://purl.org/dc/terms/description"))
+  ("o" :OBJ ("type" . "literal")
+   ("value"
+    . "The LMB system party used as an assigner of the permission in this profile")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/personAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#targetClass"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://data.vlaanderen.be/ns/persoon#Persoon")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/allowReadForPublic"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/Permission")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/administrativeUnitViewOnlyAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#NodeShape")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/lmbPublicSlice"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/2006/vcard/ns#fn"))
+  ("o" :OBJ ("type" . "literal") ("value" . "public")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/mandaatGebruikerParty"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://purl.org/dc/terms/description"))
+  ("o" :OBJ ("type" . "literal")
+   ("value"
+    . "This party collection represents all users who received the LoketLB-mandaatGebruiker role through ACM/IDM")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/authenticatedParty"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://purl.org/dc/terms/description"))
+  ("o" :OBJ ("type" . "literal")
+   ("value" . "This represents all logged in users of the system.")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b17"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#path"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b18")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/conceptSchemeAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#NodeShape")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/fractieAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#NodeShape")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/vendorGebruikerParty"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/2006/vcard/ns#fn"))
+  ("o" :OBJ ("type" . "literal") ("value" . "Vendor users")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/mandatarisAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#NodeShape")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowWriteForMandatarisOrg"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/Permission")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/lmbAuthenticatedPublicSlice"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/2006/vcard/ns#fn"))
+  ("o" :OBJ ("type" . "literal") ("value" . "view-only-modules")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b6"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#path"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b7")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/allowReadForMandatarisOrg"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/Permission")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b13"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#property"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b14")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/AssetCollection")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/graphPrefix"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/graphs/organizations/")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b1"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#path"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/2004/02/skos/core#inScheme")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/examplePolicyLMB"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/permission"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowReadForVendorOnMandatarisOrg")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/examplePolicyLMB"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/permission"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowReadForPoliceCouncilOnMandatarisOrg")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b9"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#inversePath"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/vocabularies/lmb/InstallatievergaderingStatus")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/examplePolicyLMB"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/permission"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowReadForAuthenticatedOnViewOnlyModules")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/lmbAuthenticatedPublicSlice"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/AssetCollection")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowReadForPoliceCouncilOnMandatarisOrg"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/Permission")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/examplePolicyLMB"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/Set")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/personInversPathAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/Asset")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/examplePolicyLMB"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/permission"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/allowReadForPublic")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/personAsset"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/partOf"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/examplePolicyLMB"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/permission"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowReadForMandatarisOrg")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/conceptAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#NodeShape")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/policeCouncilParty"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/definedBy"))
+  ("o" :OBJ ("type" . "literal")
+   ("value" . "
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+  SELECT DISTINCT ?session_group ?session_role WHERE {
+    <SESSION_ID> ext:sessionGroup ?original_session_group ;
+                  ext:sessionRole ?session_role .
+    ?original_session_group ext:deeltBestuurVan/mu:uuid ?session_group .
+
+    FILTER( ?session_role = \"LoketLB-mandaatGebruiker\" )
+  }
+  ")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowReadForVendorOnMandatarisOrg"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/Permission")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/examplePolicyLMB"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/permission"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowWriteForMandatarisOrg")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/lmbAuthenticatedPublicSlice"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/graphPrefix"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/graphs/authenticated/public")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/publicParty"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/definedBy"))
+  ("o" :OBJ ("type" . "literal")
+   ("value" . "
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+  SELECT DISTINCT * WHERE {
+    VALUES ?session {
+      <SESSION_ID>
+    }
+    ?session a ?thing .
+  }
+  ")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b15"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#path"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://data.vlaanderen.be/ns/persoon#heeftGeboorte")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b8"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#path"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b9")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/personInversPathAsset"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/partOf"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowReadForAuthenticatedOnViewOnlyModules"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/Permission")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/examplePolicyLMB"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/profile"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/muAuthProfile")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b5"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#inversePath"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/all")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/authenticatedParty"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/2006/vcard/ns#fn"))
+  ("o" :OBJ ("type" . "literal") ("value" . "Authenticated user")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/queryParameters"))
+  ("o" :OBJ ("type" . "literal") ("value" . "session_role")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/personAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#NodeShape")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/administrativeUnitAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/Asset")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/lmbSystem"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/Party")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/administrativeUnitViewOnlyAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/Asset")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/queryParameters"))
+  ("o" :OBJ ("type" . "literal") ("value" . "session_group")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/conceptSchemeAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/Asset")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/personInversPathAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#targetClass"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://data.vlaanderen.be/ns/persoon#Persoon")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/personMultipleExcludedAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/Asset")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/authenticatedParty"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/definedBy"))
+  ("o" :OBJ ("type" . "literal")
+   ("value" . "
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+  SELECT DISTINCT ?session_group ?session_role WHERE {
+    <SESSION_ID> ext:sessionGroup/mu:uuid ?session_group ;
+                 ext:sessionRole ?session_role .
+  }
+  ")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/administrativeUnitViewOnlyAsset"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/partOf"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/lmbAuthenticatedPublicSlice")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/geslachtCodeAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/Asset")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/conceptAsset"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/partOf"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/lmbPublicSlice")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/vendorGebruikerParty"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/definedBy"))
+  ("o" :OBJ ("type" . "literal")
+   ("value" . "
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+  SELECT DISTINCT ?session_group ?session_role WHERE {
+    VALUES ?session {
+      <SESSION_ID>
+    }
+    {{
+      ?session muAccount:canActOnBehalfOf/mu:uuid ?session_group ;
+                    muAccount:account/ext:sessionRole ?session_role .
+    } UNION {
+      ?session muAccount:account ?account .
+      ?session muAccount:canActOnBehalfOf/ext:isOCMWVoor/mu:uuid ?session_group ;
+                              muAccount:account/ext:sessionRole ?session_role .
+      ?session muAccount:canActOnBehalfOf/ext:isOCMWVoor/^<http://lblod.data.gift/vocabularies/lmb/heeftBestuurseenheid>/<http://lblod.data.gift/vocabularies/lmb/hasStatus> <http://data.lblod.info/id/concept/InstallatievergaderingStatus/a40b8f8a-8de2-4710-8d9b-3fc43a4b740e> .
+      VALUES ?account {
+        <http://data.lblod.info/vendors/14db001d-ea0f-4a8a-8453-c48547347588> # Cipal
+        <http://data.lblod.info/vendors/42edb420-08c7-4ede-9961-bc0e527d0f3b> # Green Valley
+        <http://data.lblod.info/vendors/dc62419e-1267-44e7-9562-0114e2708b6f> # Remmicom
+      }
+    }}
+  }
+  ")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b3"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#path"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b11"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#property"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b12")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/personMultipleExcludedAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#targetClass"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://data.vlaanderen.be/ns/persoon#Persoon")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/vendorGebruikerParty"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/queryParameters"))
+  ("o" :OBJ ("type" . "literal") ("value" . "session_role")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/publicParty"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://purl.org/dc/terms/description"))
+  ("o" :OBJ ("type" . "literal")
+   ("value"
+    . "This party represent all (possibly not logged in) users of the system.")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/fractieAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#targetClass"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://data.vlaanderen.be/ns/mandaat#Fractie")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://purl.org/dc/terms/description"))
+  ("o" :OBJ ("type" . "literal")
+   ("value"
+    . "This asset collection contains all information that is available to users with the LoketLB-mandaatGebruiker role in the context of the LMB app.")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b12"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#path"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://data.vlaanderen.be/ns/persoon#registratie")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/policeCouncilParty"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/queryParameters"))
+  ("o" :OBJ ("type" . "literal") ("value" . "session_role")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/authenticatedParty"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/PartyCollection")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b7"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#inversePath"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/regorg#orgStatus")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowReadForVendorOnMandatarisOrg"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/target"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/lmbPublicSlice"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://purl.org/dc/terms/description"))
+  ("o" :OBJ ("type" . "literal")
+   ("value"
+    . "This asset collection contains all information that is available to the public in the context of the LMB app.")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/allowReadForPublic"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/action"))
+  ("o" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/read")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/mandaatGebruikerParty"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/PartyCollection")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/conceptSchemeAsset"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#property"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b1")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b14"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#path"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://data.vlaanderen.be/ns/persoon#registratie")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowReadForPoliceCouncilOnMandatarisOrg"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/target"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/mandatarisAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#targetClass"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://data.vlaanderen.be/ns/mandaat#Mandataris")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/vendorGebruikerParty"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/queryParameters"))
+  ("o" :OBJ ("type" . "literal") ("value" . "session_group")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/mandaatGebruikerParty"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/2006/vcard/ns#fn"))
+  ("o" :OBJ ("type" . "literal") ("value" . "Mandaten users")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowReadForAuthenticatedOnViewOnlyModules"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/target"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/lmbAuthenticatedPublicSlice")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/conceptAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#targetClass"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/2004/02/skos/core#Concept")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/fractieAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/Asset")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowWriteForMandatarisOrg"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/action"))
+  ("o" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/modify")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/policeCouncilParty"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/queryParameters"))
+  ("o" :OBJ ("type" . "literal") ("value" . "session_group")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/personMultipleExcludedAsset"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/partOf"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/lmbPublicSlice"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/graphPrefix"))
+  ("o" :OBJ ("type" . "uri") ("value" . "http://mu.semte.ch/graphs/public")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/allowReadForMandatarisOrg"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/action"))
+  ("o" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/read")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/vendorGebruikerParty"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://purl.org/dc/terms/description"))
+  ("o" :OBJ ("type" . "literal")
+   ("value"
+    . "This party collection represents all users who can access the information regarding communes or OCMWs through their vendor api key")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b18"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#inversePath"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/lmbAuthenticatedPublicSlice"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://purl.org/dc/terms/description"))
+  ("o" :OBJ ("type" . "literal")
+   ("value"
+    . "This asset collection contains all information that is available to all authenticated users in the context of the LMB app.")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/geslachtCodeAsset"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/partOf"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/lmbPublicSlice")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/mandatarisAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/Asset")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/mandaatGebruikerParty"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/queryParameters"))
+  ("o" :OBJ ("type" . "literal") ("value" . "session_role")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowReadForPoliceCouncilOnMandatarisOrg"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/action"))
+  ("o" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/read")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/publicParty"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/PartyCollection")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowReadForVendorOnMandatarisOrg"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/action"))
+  ("o" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/read")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b2"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#path"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/2004/02/skos/core#prefLabel")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/allowReadForMandatarisOrg"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/target"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/personAsset"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#not"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b11")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/personInversPathAsset"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#not"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b16")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/conceptAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/Asset")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b4"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/shacl#path"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://lblod.data.gift/bnode/n950739537b524263b0340509e4433910b5")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/administrativeUnitViewOnlyAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#targetClass"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowWriteForMandatarisOrg"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/target"))
+  ("o" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value"
+    . "http://mu.semte.ch/vocabularies/ext/allowReadForAuthenticatedOnViewOnlyModules"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/action"))
+  ("o" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/read")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/personInversPathAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#NodeShape")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/allowReadForPublic"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/odrl/2/assignee"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/publicParty")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/administrativeUnitAsset"))
+  ("p" :OBJ ("type" . "uri")
+   ("value" . "http://www.w3.org/ns/shacl#targetClass"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid")))
+ (:OBJ
+  ("s" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/administrativeUnitAsset"))
+  ("p" :OBJ ("type" . "uri") ("value" . "http://www.w3.org/ns/odrl/2/partOf"))
+  ("o" :OBJ ("type" . "uri")
+   ("value" . "http://mu.semte.ch/vocabularies/ext/lmbPublicSlice")))))


### PR DESCRIPTION
This PR improves the service's functionality to retrieve policy data from the backend and converting this to object instances of the service's ODRL and SHACL models. Concretely this PR proposes two main changes:
- Rewrite the functionality to retrieve policy data from the backend to reduce the number of queries.
- Add some fault tolerance so that the service can handle incomplete required data.

## Rewrite functionality to retrieve policy data
The service now retrieves all policy data using a single `CONSTRUCT` query instead of multiple `SELECT` queries. The received jsown objects as passed as argument to the functions that create ODRL/SHACL object instances, the `make-*` functions in `policy-retrieval.lisp`. The individual `make-*` functions search and parse the necessary data from that argument. This avoids them querying the backend each time.

Furthermore, the order in which to ODRL/SHACL object instances are created is inverted. Previously, the creation started from permissions and from there moved on to the linked party collections, asset collections, and assets. But since multiple permissions can link to the same target and/or assignee collection this flow can cause multiple object instances to be created for the same resource. To avoid this duplication, the order is now:
1) for each Asset resource, create a `shacl:node-shape` object;
2) for each Asset Collection and Party Collection resource, create an `odrl:asset-collection` or `odrl:party-collection` object respectively; and
3) for each Permission resource, create an `odrl:permission` object.

The result of each step is used as part of the input for the subsequent step. So the `shacl:node-shape`s instances from step 1 are used when creating `odrl:asset-collection`s in step 2, that way an asset collection can reference to its contained assets. Similarly, step 3 takes the created `odrl:asset-collection`s and `odrl:party-collection`s from step 2 as input so that the created `odrl:permission`s reference the appropriate targets and assignees.

Note, these improvements rely on the ODRL policy model change proposed in [#2](https://github.com/lblod/odrl-parser-service/pull/2).

## Fault tolerance with respect to incomplete data
Previously there were no explicit checks on whether all necessary data was present when converting a policy. For example, each party collection *must* have a name. Consequently, the service would handle data issues rather inelegantly with crashes etc.

These changes make the service more resilient with respect to faulty and/or incomplete policy data in the backend. Introduce a condition `no-data-for-mandatory-slots-error` that can be used to signal when an object instance cannot be created due missing data for a mandatory slot. To simplify signalling that condition the `with-mandatory-slots` macro is introduced. This macro allows to specify a list of mandatory slots and their intended initialisation value. If any of the provided initialisation values is nil a `no-data-for-mandatory-slots-error` will be signalled.

If a condition is signalled, a message informing the user of this is printed to the standard output. In such as case no configuration file will be written, and thus no existing files will be overwritten.

## Other changes
Aside from this there are some smaller changes:
- Additional `print-object` methods for odrl objects and some test data for policy-retrieval. These are used to simplify testing/debugging individual functions.
- Silence some compiler warnings about unused arguments.
- Write the messages from the API functions to the standard output, that way they appear in the docker logs.

## How to test
The proposed changes do not modify the overall functionality of the service, at least not when the input data is correct. Thus any generated policy should be equivalent to one generated without these changes. See the "How to test" section in [#2](https://github.com/lblod/odrl-parser-service/pull/2) for information on how the check this.

To test whether the service can handle missing mandatory data you will have to fiddle with the data in the database by deleting some data (and restoring it afterwards to avoid you keep running into the same errors.) The mandatory triples for each resource are:
- `odrl:Set`: at least one permission must be linked using the `odrl:permission` predicate
- `odrl:Permission`: each permission must have an `odrl:action`, `odrl:target`, and `odrl:assignee`
- `odrl:PartyCollection`: each party collection must have a name via the `vcard:fn` predicate
- `odrl:AssetCollection`: each asset collection must have a name and graph (prefix) via the `vcard:fn` and `ext:graphPrefix` predicates respectively

## Related tickets
- LBRON-560