### PR TITLE
feat: allow more flexibility when loading data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,12 @@
 ### Fixed
 - Correctly bind the policy variable in the query to retrieve policy data.
 
+### Added
+- Allow to specify a filename to load policies from. ([#7](https://github.com/lblod/odrl-parser-service/pull/7))
+- Added API function to load prefixes from a TTL file ([#7](https://github.com/lblod/odrl-parser-service/pull/7))
+
 ### Changed
-- Improve error handling when trying to read from non-existing configuration files.
+- Improve error handling when trying to read from non-existing configuration files ([#7](https://github.com/lblod/odrl-parser-service/pull/7))
 
 ## v0.0.4 (2025-12-08)
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Insert the triples for the ODRL policy specified in the file `config/NAME.nt`. I
 Load the prefixes declared in `config/NAME.ttl` into the service. If not `NAME` is provided, the file `config/config.ttl` is used as fallback. The service will use the loaded prefixes generated configuration files.
 
 > [!warning]
-> The loaded prefixes are **not** persisted and have to be reloaded after restarting the service. To automatically load prefixes on starting the service, declare them in `config/config.ttl`.
+> The loaded prefixes are **not** persisted and have to be reloaded after restarting the service. To automatically load prefixes on starting the service, declare them in `config/prefixes.ttl`.
 
 Note, loading prefixes has no impact on the meaning of the generated
 `sparql-parser` configurations. But they can have a positive impact on

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ odrl-parser
 
 
 ## API
-### `GET /load-policy`
-Insert the triples for the ODRL policy defined in `config/config.nt` into the backend's triplestore. Furthermore, this will read any prefixes declared in `config/config.ttl` and register these in the service. The underlying assymption is that the ntriples file was generated from the ttl file.
+### `POST /load-policy[?filename=NAME]`
+Insert the triples for the ODRL policy specified in the file `config/NAME.nt`. If no `NAME` is provided, `config/config.nt` is used as fallback. The service will also look for a corresponding `config/NAME.ttl` and, if found, load any prefixes defined in that file. These prefixes are useful to improved the readability of any generated configuration files.
 
 ### `GET /generate-config[?policy-name=NAME]`
 Generate the sparql-parser configuration for a stored ODRL policy `NAME`. Here `NAME` should be the last past of the URI of a `odrl:Set` resource. If no policy name is provided the service will generate a configuration for each `odrl:Set` resource it finds in the database.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,46 @@ odrl-parser
 ### `POST /load-policy[?filename=NAME]`
 Insert the triples for the ODRL policy specified in the file `config/NAME.nt`. If no `NAME` is provided, `config/config.nt` is used as fallback. The service will also look for a corresponding `config/NAME.ttl` and, if found, load any prefixes defined in that file. These prefixes are useful to improved the readability of any generated configuration files.
 
+### `POST /load-prefixes[?filename=NAME]`
+Load the prefixes declared in `config/NAME.ttl` into the service. If not `NAME` is provided, the file `config/config.ttl` is used as fallback. The service will use the loaded prefixes generated configuration files.
+
+> [!warning]
+> The loaded prefixes are **not** persisted and have to be reloaded after restarting the service. To automatically load prefixes on starting the service, declare them in `config/config.ttl`.
+
+Note, loading prefixes has no impact on the meaning of the generated
+`sparql-parser` configurations. But they can have a positive impact on
+the readability such configurations. For example, the following
+snippet could be generated when no (relevant) prefixes are loaded:
+
+``` common-lisp
+(define-graph public ("http://mu.semte.ch/graphs/public")
+  ("http://data.europa.eu/eli/eli-draft-legislation-ontology#LegislativeProcessWork" -> _)
+  ("http://www.w3.org/ns/org#Organization" -> _)
+  ("http://www.w3.org/2004/02/skos/core#Concept" -> _)
+  ("http://data.europa.eu/eli/ontology#Expression" -> _)
+  ("http://data.vlaanderen.be/ns/besluit#Bestuurseenheid" -> _))
+```
+
+With the appropriate prefixes loaded in the service the same snippet would be
+generated as follows:
+
+``` common-lisp
+(define-prefixes
+  :skos "http://www.w3.org/2004/02/skos/core#"
+  :org "http://www.w3.org/ns/org#"
+  :eli-dl "http://data.europa.eu/eli/eli-draft-legislation-ontology#"
+  :eli "http://data.europa.eu/eli/ontology#"
+  :besluit "http://data.vlaanderen.be/ns/besluit#")
+
+(define-graph public ("http://mu.semte.ch/graphs/public")
+  ("eli-dl:LegislativeProcessWork" -> _)
+  ("org:Organization" -> _)
+  ("skos:Concept" -> _)
+  ("eli:Expression" -> _)
+  ("besluit:Bestuurseenheid" -> _)
+```
+
+
 ### `GET /generate-config[?policy-name=NAME]`
 Generate the sparql-parser configuration for a stored ODRL policy `NAME`. Here `NAME` should be the last past of the URI of a `odrl:Set` resource. If no policy name is provided the service will generate a configuration for each `odrl:Set` resource it finds in the database.
 

--- a/configuration-parsing.lisp
+++ b/configuration-parsing.lisp
@@ -22,6 +22,7 @@ If FILENAME is nil, fall back to the \"config\" as default name for the policy f
         ;; TODO(C): look into usage of `without-update-group' macro
         (sparql:insert (apply #'concatenate 'string triples))
         (format t "~& >> INFO: Loaded policy from ~A" path)
+        (load-prefixes-from-file filename))
     (error (e)
       (format t "~& >> WARN: An error occurred when trying to read the configuration file: ~% >>>> '~A'~%" e))))
 
@@ -86,7 +87,9 @@ If FILENAME is nil, fall back to the \"config\" as default name for the policy f
 ;; along with that.
 (defun prefixes-file (&optional filename)
   "Get the file to read the needed prefixes from."
-  (cl-ppcre:regex-replace "\\.nt$" (policy-file filename) ".ttl"))
+    (if (find :docker *features*)
+      (concatenate 'string "../config/" (or filename "config") ".ttl")
+      "examples/config-simplified.ttl"))
 
 (defparameter prefix-declaration-regex
   "@prefix +([a-zA-Z0-9_-]+): +<([a-zA-Z0-9:/#-_]+)> *\."

--- a/configuration-parsing.lisp
+++ b/configuration-parsing.lisp
@@ -4,28 +4,30 @@
 ;;
 ;; Read an ODRL policy specified as n-triples in a file and insert the triples into the backend.
 
-;; TODO(B): Make exact policy file configurable
-(defparameter *policy-file*
-  (if (find :docker *features*)
-      "../config/config.nt"
-      "examples/config-simplified.nt")
-  "The file to read the ODRL policy from.")
+(defun policy-file (&optional filename)
+  "Get the path to the file to read the ODRL policy from.
 
-(defun load-policy-file ()
-  "Load the ODRL policy from `*policy-file*' and insert the triples in the triplestore."
+If FILENAME is nil, fall back to the \"config\" as default name for the policy file."
+  (if (find :docker *features*)
+      (concatenate 'string "../config/" (or filename "config") ".nt")
+      "examples/config-simplified.nt"))
+
+(defun load-policy-file (&optional filename)
+  "Load the ODRL policy from `policy-file' and insert the triples in the triplestore."
   (handler-case
-      (let* ((string-content (read-ntriples-file))
+      (let* ((path (policy-file filename))
+             (string-content (read-ntriples-file path))
              (parsed-content (nt:parse-nt string-content))
              (triples (mapcar #'triple-to-string parsed-content)))
         ;; TODO(C): look into usage of `without-update-group' macro
         (sparql:insert (apply #'concatenate 'string triples))
-        (format t "~& >> INFO: Loaded policy from ~A" *policy-file*))
+        (format t "~& >> INFO: Loaded policy from ~A" path)
     (error (e)
-      (format t "~& >> WARN: An error occurred when trying to read the configuration file: \"~A\"" e))))
+      (format t "~& >> WARN: An error occurred when trying to read the configuration file: ~% >>>> '~A'~%" e))))
 
-(defun read-ntriples-file ()
-  "Read the n-triples file `*policy-file*' and return its contents as a single string."
-  (let ((path (asdf:system-relative-pathname :odrl-parser *policy-file*)))
+(defun read-ntriples-file (path)
+  "Read the n-triples file `policy-file' and return its contents as a single string."
+  (let ((path (asdf:system-relative-pathname :odrl-parser path)))
     (alexandria:read-file-into-string path)))
 
 ;; Functions to convert the triples returned by cl-ntriples parsing to plain strings that can be
@@ -82,9 +84,9 @@
 ;; prefixes without hardcoding them in the service. In the future this service should be able to
 ;; just read a policy from a ttl file instead of an ntriples file and thus get the "right" prefixes
 ;; along with that.
-(defparameter *prefixes-file*
-  (cl-ppcre:regex-replace "\\.nt$" *policy-file* ".ttl")
-  "The file to read the needed prefixes from.")
+(defun prefixes-file (&optional filename)
+  "Get the file to read the needed prefixes from."
+  (cl-ppcre:regex-replace "\\.nt$" (policy-file filename) ".ttl"))
 
 (defparameter prefix-declaration-regex
   "@prefix +([a-zA-Z0-9_-]+): +<([a-zA-Z0-9:/#-_]+)> *\."
@@ -102,11 +104,12 @@ allowed characters and allows invalid start characters.")
   (cl-ppcre:register-groups-bind (label iri) (prefix-declaration-regex declaration)
     (add-prefix label iri)))
 
-(defun load-prefixes-from-file ()
-  "Read all prefixes declared in a config file and register them using `add-prefix'."
+(defun load-prefixes-from-file (&optional filename)
+  "Read all prefixes declared in FILENAME and register them using `add-prefix'."
   (handler-case
-      (let ((path (asdf:system-relative-pathname :odrl-parser *prefixes-file*)))
-        (mapcar #'append-prefix-for-declaration (read-prefixes-from-file path))
-        (format t "~& INFO: Loaded prefixes from ~A" path))
+      (let* ((path (prefixes-file filename))
+             (rel-path (asdf:system-relative-pathname :odrl-parser path)))
+        (mapcar #'append-prefix-for-declaration (read-prefixes-from-file rel-path))
+        (format t "~& >> INFO: Loaded prefixes from ~A" path))
     (error (e)
-      (format t "~& >> WARN: could not find configuration file to load prefixes"))))
+      (format t "~& >> WARN: An error occurred when trying to read the prefixes from file: ~% >>>> '~A'~%" e))))

--- a/odrl-parser.lisp
+++ b/odrl-parser.lisp
@@ -42,8 +42,7 @@ image."
 
 (hunchentoot:define-easy-handler (generate-config :uri "/generate-config") (policy-name)
   (setf (hunchentoot:content-type*) "text/plain")
-  (generate-authorisation-configuration policy-name)
-  (format t "~& >> Generated authorisation configurations"))
+  (generate-authorisation-configuration policy-name))
 
 (defun extract-filename (uri)
   "Extract a file name from the given uri."
@@ -56,17 +55,19 @@ If POLICY-NAME is nil a configuration is generated for each `odrl:Set' resource 
 backend.  Each policy is written to a file in `output-directory' with the policy's name used as
 filename."
   (let ((policy-uris (if policy-name
-                         `(,(format nil "ext:~a" policy-name))
+                         `(,(format nil "ext:~A" policy-name))
                          (policy-retrieval:list-known-policies))))
     (loop
       for uri in policy-uris
       do (handler-case
-             (let ((conf (odrl:odrl-to-acl (policy-retrieval:parse-stored-policy uri))))
+             (let ((conf (odrl:odrl-to-acl (policy-retrieval:parse-stored-policy uri)))
+                   (output-file (concatenate 'string output-directory (extract-filename uri) ".lisp")))
                (with-open-file
-                 (stream
-                  (concatenate 'string output-directory (extract-filename uri) ".lisp")
-                  :direction :output
-                  :if-exists :supersede)
-               (write conf :stream stream)))
+                   (stream
+                    output-file
+                    :direction :output
+                    :if-exists :supersede)
+                 (write conf :stream stream))
+               (format t "~& >> INFO: Wrote policy to file: ~A" output-file))
            (error (e)
-             (format t "~& >> WARN: An error occurred when parsing policy \"~a\", no configuration written: \"~a\"" uri e))))))
+             (format t "~& >> WARN: An error occurred when parsing policy \"~A\", no configuration written: \"~A\"" uri e))))))

--- a/odrl-parser.lisp
+++ b/odrl-parser.lisp
@@ -36,7 +36,9 @@ image."
   (setf (hunchentoot:content-type*) "text/plain")
   (load-policy-file filename))
 
+(hunchentoot:define-easy-handler (load-prefixes :uri "/load-prefixes") (filename)
   (setf (hunchentoot:content-type*) "text/plain")
+  (load-prefixes-from-file filename))
 
 (hunchentoot:define-easy-handler (generate-config :uri "/generate-config") (policy-name)
   (setf (hunchentoot:content-type*) "text/plain")

--- a/odrl-parser.lisp
+++ b/odrl-parser.lisp
@@ -32,11 +32,11 @@ image."
 ;;
 ;; NOTE (13/09/2025): Over time this should probably be re-implemented using some web-framework or
 ;; something.  But for the moment this suffices.
-
-;; TODO(B): add argument to provide name for config file
-(hunchentoot:define-easy-handler (load-policy :uri "/load-policy") ()
+(hunchentoot:define-easy-handler (load-policy :uri "/load-policy") (filename)
   (setf (hunchentoot:content-type*) "text/plain")
-  (load-policy-file))
+  (load-policy-file filename))
+
+  (setf (hunchentoot:content-type*) "text/plain")
 
 (hunchentoot:define-easy-handler (generate-config :uri "/generate-config") (policy-name)
   (setf (hunchentoot:content-type*) "text/plain")

--- a/odrl-parser.lisp
+++ b/odrl-parser.lisp
@@ -23,7 +23,7 @@ image."
   (format t "~& >> Using port: ~a" *port*)
   (mu-support:boot)
   (format t "~& >> Loading prefixes")
-  (load-prefixes-from-file)
+  (load-prefixes-from-file *default-prefixes-file*)
   (format t "~& >> Finished boot function"))
 
 

--- a/settings.lisp
+++ b/settings.lisp
@@ -1,9 +1,14 @@
 (in-package :odrl-parser)
 
 ;; Sparql
-;; Add prefixes used by this service
+;;;; The following two prefixes are relevant to any ODRL authorization policy, might as well load by
+;;;; default so they are always available in this service.
 (add-prefix "odrl" "http://www.w3.org/ns/odrl/2/")
 (add-prefix "sh" "http://www.w3.org/ns/shacl#")
+
+(defparameter *default-prefixes-file* "prefixes"
+  "The name of the file from which to try to read prefix declarations on boot.")
+
 
 (defparameter sparql:*application-graph*
   (s-url (or (uiop:getenv "ODRL_POLICY_GRAPH")


### PR DESCRIPTION
Extend the service's API to allow more flexibility when loading data from files. More specifically, this adds functionality to specify a filename to load policy data from as well as load prefixes from specified files. Both are limited to files located in the mounted `/config` volume. Furthermore, when running the service as a local REPL on host, outside of docker, it will keep using the example files included in this repository.

## Allow users to specify file to load policy data
The `/load-policy` API call now allows to provide a value `NAME` for an optional `filename` parameter. The service will look for a file `NAME.nt` in the mounted `/confg` volume. If such a file exists its contents will be read, parsed, and inserted in to the policy graph. If no suitable file is found a warning message is printed in the logs. If the user does not provide a filename, the service will use `config.nt` as default policy file.

Furthermore, when loading a policy from a file the service will also look for a TTL file with the same name. If such a file exists, its prefix declarations are read and added to the prefixes known by the service. This allows to use these prefixes when generating `sparql-parser` configurations. The underlying assumption is that users will not directly write the N-triples file but generate this from a TTL file.

## Load prefixes from user-specified files
The service's API is extend with an additional endpoint `/load-prefixes` which accepts an optional `filename` argument. This can be used to load additional prefixes into the service from TTL files.

Note, the loaded prefixes are not persisted and are lost when stopping or restarting the service. Any required prefixes should thus be reloaded after (re)starting the service. To simplify this process, the service will look for a `prefixes.ttl` file on boot and try to load the prefixes declared therein.

## Notes
Whether prefixes are loaded or not has no impact on the meaning of the generated `sparql-parser` configurations. But using prefixes can have a positive impact on the readability of the generated configurations. For example, the following snippet could be generated when no (relevant) prefixes are loaded:

``` common-lisp
(define-graph public ("http://mu.semte.ch/graphs/public")
  ("http://data.europa.eu/eli/eli-draft-legislation-ontology#LegislativeProcessWork" -> _)
  ("http://www.w3.org/ns/org#Organization" -> _)
  ("http://www.w3.org/2004/02/skos/core#Concept" -> _)
  ("http://data.europa.eu/eli/ontology#Expression" -> _)
  ("http://data.vlaanderen.be/ns/besluit#Bestuurseenheid" -> _))
```

If the appropriate prefixes are loaded in the service the same snippet would be generated as follows:

``` common-lisp
(define-prefixes
  :skos "http://www.w3.org/2004/02/skos/core#"
  :org "http://www.w3.org/ns/org#"
  :eli-dl "http://data.europa.eu/eli/eli-draft-legislation-ontology#"
  :eli "http://data.europa.eu/eli/ontology#"
  :besluit "http://data.vlaanderen.be/ns/besluit#")

(define-graph public ("http://mu.semte.ch/graphs/public")
  ("eli-dl:LegislativeProcessWork" -> _)
  ("org:Organization" -> _)
  ("skos:Concept" -> _)
  ("eli:Expression" -> _)
  ("besluit:Bestuurseenheid" -> _)
```